### PR TITLE
Single-source social links from social.json

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,3 +31,4 @@ Five content types from Contentful: **productions**, **graphics**, **music**, **
 - Two themes available (`theme-joe.css` dark, `theme-first.css` light), controlled by `site.theme` in `src/_data/site.js`
 - Music nav item is hidden by default, revealed via `?mode=wotw` URL parameter
 - Images processed to 3 WebP sizes (orig, card/400px, post/150px) via Sharp
+- Social links live only in `src/_data/social.json`; each entry's `locations` array (`header`, `footer`, `about`, `schema`) picks the surfaces it renders on, and `icon` names an SVG in `src/icons/` (required for `header`, optional elsewhere)

--- a/src/_data/social.json
+++ b/src/_data/social.json
@@ -1,20 +1,33 @@
 {
   "nav_items": [
     {
-      "name": "Facebook",
-      "url": "https://www.facebook.com/tristarandredsector/"
+      "name": "Westpoint BBS",
+      "url": "https://westpoint.fun/",
+      "locations": ["footer", "about"]
     },
     {
-      "name": "Youtube",
-      "url": "https://www.youtube.com/@trsi"
+      "name": "Facebook",
+      "url": "https://www.facebook.com/tristarandredsector/",
+      "icon": "facebook",
+      "locations": ["header", "footer", "about", "schema"]
     },
     {
       "name": "X",
-      "url": "https://x.com/trsi"
+      "url": "https://x.com/trsi",
+      "icon": "x",
+      "locations": ["header", "footer", "about", "schema"]
     },
     {
       "name": "Instagram",
-      "url": "https://www.instagram.com/_trsi_/"
+      "url": "https://www.instagram.com/_trsi_/",
+      "icon": "instagram",
+      "locations": ["header", "footer", "about", "schema"]
+    },
+    {
+      "name": "YouTube",
+      "url": "https://www.youtube.com/@trsi",
+      "icon": "youtube",
+      "locations": ["header", "footer", "about", "schema"]
     }
   ]
 }

--- a/src/_includes/sections/footer.liquid
+++ b/src/_includes/sections/footer.liquid
@@ -24,7 +24,8 @@
           <div>
             <div class="footer__heading">Connect</div>
             <div class="footer__links">
-            {%- for item in social.nav_items %}
+            {%- assign social_footer = social.nav_items | where_exp: "item", "item.locations contains 'footer'" %}
+            {%- for item in social_footer %}
               <a href="{{ item.url }}" target="_blank" rel="noopener">{{ item.name }}</a>
             {%- endfor %}
             </div>

--- a/src/_includes/sections/header.liquid
+++ b/src/_includes/sections/header.liquid
@@ -13,18 +13,13 @@
             </li>
           {%- endfor %}
             <li class="nav__social">
-              <a href="https://www.instagram.com/_trsi_/" target="_blank" rel="noopener" class="nav__social-link" aria-label="Connect with TRSI on Instagram">
-                {%- include "icons/instagram.svg" %}
+            {%- assign social_header = social.nav_items | where_exp: "item", "item.locations contains 'header'" %}
+            {%- for item in social_header %}
+              {%- assign icon_path = "icons/" | append: item.icon | append: ".svg" %}
+              <a href="{{ item.url }}" target="_blank" rel="noopener" class="nav__social-link" aria-label="Connect with TRSI on {{ item.name }}">
+                {%- include icon_path %}
               </a>
-              <a href="https://www.facebook.com/tristarandredsector/" target="_blank" rel="noopener" class="nav__social-link" aria-label="Connect with TRSI on Facebook">
-                {%- include "icons/facebook.svg" %}
-              </a>
-              <a href="https://x.com/trsi" target="_blank" rel="noopener" class="nav__social-link" aria-label="Connect with TRSI on X">
-                {%- include "icons/x.svg" %}
-              </a>
-              <a href="https://www.youtube.com/@trsi" target="_blank" rel="noopener" class="nav__social-link" aria-label="Connect with TRSI on YouTube">
-                {%- include "icons/youtube.svg" %}
-              </a>
+            {%- endfor %}
             </li>
           </ul>
 

--- a/src/_includes/sections/jsonld-organisation.liquid
+++ b/src/_includes/sections/jsonld-organisation.liquid
@@ -10,10 +10,10 @@
       "foundingDate": "1990",
       "keywords": "demoscene, c64, amiga, intro, music, graphics, TRSI, computer art",
       "sameAs": [
-        "https://www.instagram.com/_trsi_/",
-        "https://www.facebook.com/tristarandredsector/",
-        "https://x.com/trsi",
-        "https://www.youtube.com/@trsi"
+      {%- assign social_schema = social.nav_items | where_exp: "item", "item.locations contains 'schema'" -%}
+      {%- for item in social_schema %}
+        "{{ item.url }}"{% unless forloop.last %},{% endunless %}
+      {%- endfor %}
       ]
     }
     </script>

--- a/src/about.liquid
+++ b/src/about.liquid
@@ -24,18 +24,12 @@ tags: page
 
           <p>Join us on the journey and follow our social media channels!</p>
           <div class="prose__socials">
-            <a href="https://www.instagram.com/_trsi_/" target="_blank" rel="noopener" class="prose__social-link">
-              {%- include "icons/instagram.svg" %} Instagram
+          {%- assign social_about = social.nav_items | where_exp: "item", "item.locations contains 'about'" %}
+          {%- for item in social_about %}
+            <a href="{{ item.url }}" target="_blank" rel="noopener" class="prose__social-link">
+              {%- if item.icon %}{%- assign icon_path = "icons/" | append: item.icon | append: ".svg" %}{% include icon_path %}{% endif %} {{ item.name }}
             </a>
-            <a href="https://www.facebook.com/tristarandredsector/" target="_blank" rel="noopener" class="prose__social-link">
-              {%- include "icons/facebook.svg" %} Facebook
-            </a>
-            <a href="https://x.com/trsi" target="_blank" rel="noopener" class="prose__social-link">
-              {%- include "icons/x.svg" %} X
-            </a>
-            <a href="https://www.youtube.com/@trsi" target="_blank" rel="noopener" class="prose__social-link">
-              {%- include "icons/youtube.svg" %} YouTube
-            </a>
+          {%- endfor %}
           </div>
 
           <h2>What is the demoscene?</h2>


### PR DESCRIPTION
Header, footer, About page and JSON-LD sameAs each hardcoded their own copy of the social links, so every addition meant four edits and the lists had drifted apart in order and spelling ("Youtube" vs "YouTube"). All four now render from src/_data/social.json.

Each entry carries a `locations` array (header, footer, about, schema) picking the surfaces it appears on, and an `icon` naming an SVG in src/icons/ — required for the icon-only header, optional elsewhere. This allows adding Westpoint BBS to the footer and About page without an icon for it.